### PR TITLE
Cops 127: Merge nginx_status page & Ingress controller monitoring 

### DIFF
--- a/ingress/controllers/nginx-alpha-ssl/Dockerfile
+++ b/ingress/controllers/nginx-alpha-ssl/Dockerfile
@@ -16,6 +16,8 @@ FROM gcr.io/google_containers/nginx
 COPY controller /
 COPY default.conf /etc/nginx/nginx.conf
 COPY /run.sh /usr/bin/run.sh
+COPY /nginx-error-statsd.sh  /etc/nginx/nginx-error-statsd.sh
+RUN chmod +x /etc/nginx/nginx-error-statsd.sh
 
 RUN chmod +x /usr/bin/run.sh
 

--- a/ingress/controllers/nginx-alpha-ssl/controller.go
+++ b/ingress/controllers/nginx-alpha-ssl/controller.go
@@ -62,7 +62,7 @@ http {
   log_format proxied_combined '"$http_x_forwarded_for" - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" $request_time';
-  
+
   error_log /dev/stderr info;
   access_log /dev/stdout proxied_combined;
 
@@ -78,6 +78,9 @@ http {
       root   /usr/share/nginx/html;
       index index.html index.htm;
     }
+    location /ELBHealthCheck {
+			root /var/www/healthcheck/;
+		}
   }
 {{range $i := .}}
 
@@ -173,7 +176,7 @@ func main() {
   } else {
     vaultEnabled = vaultEnabledFlag
   }
- 
+
   if vaultAddress == "" || vaultToken == "" {
     fmt.Printf("\nVault not configured\n")
     vaultEnabled = "false"
@@ -214,7 +217,7 @@ func main() {
 
     for _, ingress := range ingresses.Items {
 
-      ingressHost := ingress.Spec.Rules[0].Host   
+      ingressHost := ingress.Spec.Rules[0].Host
 
       // Setup ingress defaults
 

--- a/ingress/controllers/nginx-alpha-ssl/controller.go
+++ b/ingress/controllers/nginx-alpha-ssl/controller.go
@@ -81,6 +81,15 @@ http {
     location /ELBHealthCheck {
 			root /var/www/healthcheck/;
 		}
+    location /nginx_status { # Used by sysdig-agent only. Exclude in Nginx logs.
+			stub_status on;
+			access_log off;
+			allow 127.0.0.1/32;
+			deny all;
+    }
+		location /usr_nginx_status { # Used by user with Nginx log enabled. No access control.
+			stub_status on;
+		}
   }
 {{range $i := .}}
 

--- a/ingress/controllers/nginx-alpha-ssl/controller.go
+++ b/ingress/controllers/nginx-alpha-ssl/controller.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-  version = "1.6.6"
+  version = "1.6.7"
   nginxConf = `
 daemon off;
 

--- a/ingress/controllers/nginx-alpha-ssl/default.conf
+++ b/ingress/controllers/nginx-alpha-ssl/default.conf
@@ -32,5 +32,14 @@ http {
 		location /ELBHealthCheck {
 			root /var/www/healthcheck/;
 		}
+		location /nginx_status { # Used by sysdig-agent only. Exclude in Nginx logs.
+			stub_status on;
+			access_log off;
+			allow 127.0.0.1/32;
+			deny all;
+    }
+		location /usr_nginx_status { # Used by user with Nginx log enabled. No access control.
+			stub_status on;
+		}
 	}
 }

--- a/ingress/controllers/nginx-alpha-ssl/default.conf
+++ b/ingress/controllers/nginx-alpha-ssl/default.conf
@@ -29,6 +29,8 @@ http {
 			root	 /usr/share/nginx/html;
 			index	index.html index.htm;
 		}
+		location /ELBHealthCheck {
+			root /var/www/healthcheck/;
+		}
 	}
 }
-

--- a/ingress/controllers/nginx-alpha-ssl/default.conf
+++ b/ingress/controllers/nginx-alpha-ssl/default.conf
@@ -37,7 +37,7 @@ http {
 			access_log off;
 			allow 127.0.0.1/32;
 			deny all;
-    }
+		}
 		location /usr_nginx_status { # Used by user with Nginx log enabled. No access control.
 			stub_status on;
 		}

--- a/ingress/controllers/nginx-alpha-ssl/nginx-error-statsd.sh
+++ b/ingress/controllers/nginx-alpha-ssl/nginx-error-statsd.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "nginx.config.error:1|h" > /dev/udp/127.0.0.1/8125


### PR DESCRIPTION
This branch is built above the latest dev branch. It enables the nginx_status page in the bitesize PR#49 and adds the ingress controller monitoring in the bitesize PR#86.

It can be merged into dev after merging the PR#86 into bitesize dev.
